### PR TITLE
ds_segmenter.py: Use constant digits in output segment file names

### DIFF
--- a/scripts/ds_segmenter.py
+++ b/scripts/ds_segmenter.py
@@ -24,10 +24,11 @@ def process_ds(file_path, retime, export_path):
         content_list = [content] if not isinstance(content, list) else content
     file_name, _ = os.path.splitext(os.path.basename(file_path))
 
+    digits=len(str(len(content_list)+1))
     for index, segment in enumerate(content_list):
         if retime:
             segment["offset"] = 0.5
-        exp_name = f"{file_name}_seg_{index + 1}.ds"
+        exp_name = f"{file_name}_seg_{str(index + 1).zfill(digits)}.ds"
         exp_path = os.path.join(export_path, exp_name)
         ds_segment = [segment] if not isinstance(segment, list) else segment
         with open(exp_path, "w", encoding="utf-8") as file:


### PR DESCRIPTION
Before this change, the output file names are:
```
Songname_0
Songname_1
Songname_10
Songname_11
Songname_12
...
Songname_19
Songname_2
Songname_20
Songname_21 
```
which won't order correctly in file explorer and vlabeler. That's because `Songname_0` to `Songname_9` use 1 digit, but `Songname_10` and audio files after it use 2 digits.

After this change, all the files exported will use the same number of digits:
```
Songname_01
Songname_02
...
Songname_09
Songname_10
Songname_11
...
Songname_19
Songname_20
Songname_21
```